### PR TITLE
Fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Schulze Vote
 
 This gem is a Ruby implementation of the Schulze voting method (with help of the Floyd–Warshall algorithm), 
-a type of the Condorcet voting methods. It's the backend algorithm of [Agreeder](https://agreeder.com) and [Airesis](https://airesis.ue). 
+a type of the Condorcet voting methods. It's the backend algorithm of [Agreeder](https://www.renuo.ch/en/products/agreeder) and [Airesis](https://airesis.eu). 
 
 ## Master
 


### PR DESCRIPTION
Agreeder appears to be down on Heroku linking to project overview. 

Link typo for Airesis